### PR TITLE
Removes '--no-colors' which fixes issue 3

### DIFF
--- a/src/main/scala/zio/app/Main.scala
+++ b/src/main/scala/zio/app/Main.scala
@@ -51,7 +51,7 @@ object Main extends App {
     ZStream
       .unwrap(
         for {
-          process <- Command("sbt", "--no-colors", command).run
+          process <- Command("sbt", command).run
           _       <- process.exitCode.fork
           exitStream = process.stderr.linesStream.tap { line =>
             ZIO.fail(new Error("LOCK")).when(line.contains("waiting for lock"))


### PR DESCRIPTION
Seems to resolve #3 on my local machine (`sbt -no-colors` causes an error in my environment which is a recent clean install of sbt 1.5.0 using coursier). Happy to use a specific sbt launcher instead if that's recommended for zio-app though!



