### PR TITLE
Use https to clone instead of ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ brew install zio-app
 **Via Source**
 
 ```sh
-git clone git@github.com:kitlangton/zio-app.git
+git clone https://github.com/kitlangton/zio-app.git
 cd zio-app
 sbt cli/nativeImage
 ```


### PR DESCRIPTION
While using git with ssh keys is popular, it requires an according setup. Cloning via https should work for everyone.
Only people with commit privileges would have a downside from the proposed change, as they might have to change the remote if they prefer to use ssh keys.