### PR TITLE
Building the native image now succeeds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,6 @@ lazy val cli = (project in file("cli"))
       "--allow-incomplete-classpath",
       "--no-fallback",
       "--install-exit-handlers",
-      "--libc=musl",
       "-H:+ReportExceptionStackTraces",
       "-H:+RemoveSaturatedTypeFlows",
       "-H:+TraceClassInitialization",

--- a/cli/src/main/resources/resource-config.json
+++ b/cli/src/main/resources/resource-config.json
@@ -5,7 +5,5 @@
     {"pattern":"\\Qdist/index.html\\E"}
   ],
   "bundles":[
-    {"name":"sun.awt.resources.awt"}, 
-    {"name":"sun.awt.resources.awtosx"}
   ]
 }


### PR DESCRIPTION
There were two problems:

1) Using musl instead of the standard libc works only with a static linking
2) AWT resource for OS X aren't available on all platforms, fortunately the AWT resources don't seem to be required