### PR TITLE
Support for root path

### DIFF
--- a/core/shared/src/main/scala/zio/app/ClientConfig.scala
+++ b/core/shared/src/main/scala/zio/app/ClientConfig.scala
@@ -1,8 +1,13 @@
 package zio.app
 
-final case class ClientConfig(authToken: Option[String])
+import sttp.model.Uri
+
+final case class ClientConfig(
+  authToken: Option[String],
+  root: Uri.AbsolutePath
+)
 
 object ClientConfig {
   val empty: ClientConfig =
-    ClientConfig(None)
+    ClientConfig(None, Uri.AbsolutePath(Seq.empty))
 }

--- a/core/shared/src/main/scala/zio/app/internal/macros/Macros.scala
+++ b/core/shared/src/main/scala/zio/app/internal/macros/Macros.scala
@@ -45,9 +45,9 @@ private[app] class Macros(val c: blackbox.Context) {
       val request =
         if (isStream) {
           if (params.isEmpty)
-            q"_root_.zio.app.FrontendUtils.fetchStream[$returnType](${serviceType.finalResultType.toString}, ${methodName.toString})"
+            q"_root_.zio.app.FrontendUtils.fetchStream[$returnType](${serviceType.finalResultType.toString}, ${methodName.toString}, $config)"
           else
-            q"_root_.zio.app.FrontendUtils.fetchStream[$returnType](${serviceType.finalResultType.toString}, ${methodName.toString}, Pickle.intoBytes($pickleType))"
+            q"_root_.zio.app.FrontendUtils.fetchStream[$returnType](${serviceType.finalResultType.toString}, ${methodName.toString}, Pickle.intoBytes($pickleType), $config)"
         } else {
           if (params.isEmpty)
             q"_root_.zio.app.FrontendUtils.fetch[$returnType](${serviceType.finalResultType.toString}, ${methodName.toString}, $config)"


### PR DESCRIPTION
Here are the changes required for having the ability to host a zio-app behind a reverse proxy on a specific path.
For example `https://host.com/path/` where `https://host.com/other/` would be a different application on a different server.

Only the changes for the `zio-app` library are included : a fully functional solution also requires modifying the `vite.config.js` in the g8 template.